### PR TITLE
Add FastAPI query params and tests

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,23 @@
+name: CI
+
+on:
+  push:
+    branches: [ main ]
+  pull_request:
+    branches: [ main ]
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v3
+    - name: Set up Python
+      uses: actions/setup-python@v4
+      with:
+        python-version: '3.12'
+    - name: Install dependencies
+      run: |
+        python -m pip install --upgrade pip
+        pip install -r requirements.txt
+    - name: Run tests
+      run: pytest

--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,54 @@
+__pycache__/
+*.py[cod]
+*.egg
+*.egg-info/
+.dist
+build/
+.env
+venv/
+.env/
+*.sqlite3
+*.db
+.DS_Store
+
+# Byte-compiled / optimized / DLL files
+__pycache__
+*.py[cod]
+*.so
+
+# C extensions
+*.so
+
+# Distribution / packaging
+.Python
+build/
+develop-eggs/
+dist/
+downloads/
+.eggs/
+lib/
+lib64/
+parts/
+sdist/
+var/
+*.egg-info/
+.installed.cfg
+*.egg
+
+# Virtual environment
+venv/
+ENV/
+
+# pyenv
+.python-version
+
+# mypy
+.mypy_cache/
+.dmypy.json
+
+# Pytest
+.cache/
+
+# VSCode
+.vscode/
+

--- a/README.md
+++ b/README.md
@@ -1,1 +1,49 @@
-# API-Data
+# Yahoo Finance Microservice
+
+This project provides a simple FastAPI microservice that serves Yahoo Finance price history for a given ticker.
+
+## Requirements
+
+- Python 3.12
+
+Create a virtual environment and install dependencies:
+
+```bash
+python3.12 -m venv venv
+source venv/bin/activate
+pip install -r requirements.txt
+```
+
+## Running the service
+
+```bash
+uvicorn app.main:app --reload
+```
+
+Then visit `http://localhost:8000/history/MSFT` to fetch Microsoft stock history for the last year.
+
+The `/history/{symbol}` endpoint accepts optional query parameters:
+
+* `period` - history period accepted by Yahoo Finance (default `1y`)
+* `include_dividends` - set to `true` to include dividend data
+* `include_splits` - set to `true` to include stock split data
+
+Dividends and split columns are omitted by default.
+
+Example fetching the last month of data and including dividends:
+
+```bash
+curl "http://localhost:8000/history/MSFT?period=1mo&include_dividends=true"
+```
+
+Example including both dividends and splits:
+
+```bash
+curl "http://localhost:8000/history/MSFT?period=1mo&include_dividends=true&include_splits=true"
+```
+
+## Running tests
+
+```bash
+pytest
+```

--- a/app/main.py
+++ b/app/main.py
@@ -1,0 +1,39 @@
+from fastapi import FastAPI, HTTPException
+import yfinance as yf
+
+app = FastAPI(title="Yahoo Finance History Service")
+
+@app.get("/")
+async def root():
+    return {"message": "Yahoo Finance microservice"}
+
+@app.get("/history/{symbol}")
+async def get_history(
+    symbol: str,
+    period: str = "1y",
+    include_dividends: bool = False,
+    include_splits: bool = False,
+):
+    """Return historical price data for ``symbol``.
+
+    Parameters
+    ----------
+    symbol: stock ticker symbol
+    period: history period accepted by yfinance (default "1y")
+    include_dividends: whether to include the ``Dividends`` column
+    include_splits: whether to include the ``Stock Splits`` column
+    """
+    try:
+        data = yf.Ticker(symbol).history(period=period)
+    except Exception as e:
+        raise HTTPException(status_code=500, detail=str(e))
+
+    data = data.reset_index()
+    drop_cols = []
+    if not include_dividends and "Dividends" in data.columns:
+        drop_cols.append("Dividends")
+    if not include_splits and "Stock Splits" in data.columns:
+        drop_cols.append("Stock Splits")
+    if drop_cols:
+        data = data.drop(columns=drop_cols)
+    return data.to_dict(orient="records")

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,5 @@
+fastapi
+uvicorn[standard]
+yfinance
+pytest
+httpx

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -1,0 +1,101 @@
+import os
+import sys
+
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
+
+from fastapi.testclient import TestClient
+from app.main import app
+
+client = TestClient(app)
+
+def test_root():
+    response = client.get("/")
+    assert response.status_code == 200
+    assert response.json()["message"].startswith("Yahoo Finance")
+
+
+def test_history_excludes_columns(monkeypatch):
+    import pandas as pd
+    import yfinance as yf
+
+    df = pd.DataFrame(
+        {
+            "Date": [pd.Timestamp("2024-01-01")],
+            "Open": [1],
+            "High": [1],
+            "Low": [1],
+            "Close": [1],
+            "Volume": [1],
+            "Dividends": [0.1],
+            "Stock Splits": [0],
+        }
+    ).set_index("Date")
+
+    class DummyTicker:
+        def history(self, period="1y"):
+            return df
+
+    monkeypatch.setattr(yf, "Ticker", lambda symbol: DummyTicker())
+
+    response = client.get("/history/TEST")
+    assert response.status_code == 200
+    data = response.json()[0]
+    assert "Dividends" not in data
+    assert "Stock Splits" not in data
+
+
+def test_history_include_columns(monkeypatch):
+    import pandas as pd
+    import yfinance as yf
+
+    df = pd.DataFrame(
+        {
+            "Date": [pd.Timestamp("2024-01-01")],
+            "Open": [1],
+            "High": [1],
+            "Low": [1],
+            "Close": [1],
+            "Volume": [1],
+            "Dividends": [0.1],
+            "Stock Splits": [0],
+        }
+    ).set_index("Date")
+
+    class DummyTicker:
+        def history(self, period="1y"):
+            return df
+
+    monkeypatch.setattr(yf, "Ticker", lambda symbol: DummyTicker())
+
+    response = client.get("/history/TEST?include_dividends=true&include_splits=true")
+    assert response.status_code == 200
+    data = response.json()[0]
+    assert "Dividends" in data
+    assert "Stock Splits" in data
+
+def test_history_custom_period(monkeypatch):
+    import pandas as pd
+    import yfinance as yf
+
+    called = {}
+    df = pd.DataFrame(
+        {
+            "Date": [pd.Timestamp("2024-01-01")],
+            "Open": [1],
+            "High": [1],
+            "Low": [1],
+            "Close": [1],
+            "Volume": [1],
+        }
+    ).set_index("Date")
+
+    class DummyTicker:
+        def history(self, period="1y"):
+            called["period"] = period
+            return df
+
+    monkeypatch.setattr(yf, "Ticker", lambda symbol: DummyTicker())
+
+    response = client.get("/history/TEST?period=5d")
+    assert response.status_code == 200
+    assert called["period"] == "5d"


### PR DESCRIPTION
## Summary
- update FastAPI endpoint to allow period and column filtering
- document new options in README
- test history endpoint using monkeypatch
- test that custom period is forwarded to yfinance

## Testing
- `pip install -r requirements.txt`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68734b61ad2c83289e08984d7a991552