### PR TITLE
Remove optional params for simple API

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,23 @@
+name: CI
+
+on:
+  push:
+    branches: [ main ]
+  pull_request:
+    branches: [ main ]
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v3
+    - name: Set up Python
+      uses: actions/setup-python@v4
+      with:
+        python-version: '3.12'
+    - name: Install dependencies
+      run: |
+        python -m pip install --upgrade pip
+        pip install -r requirements.txt
+    - name: Run tests
+      run: pytest

--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,54 @@
+__pycache__/
+*.py[cod]
+*.egg
+*.egg-info/
+.dist
+build/
+.env
+venv/
+.env/
+*.sqlite3
+*.db
+.DS_Store
+
+# Byte-compiled / optimized / DLL files
+__pycache__
+*.py[cod]
+*.so
+
+# C extensions
+*.so
+
+# Distribution / packaging
+.Python
+build/
+develop-eggs/
+dist/
+downloads/
+.eggs/
+lib/
+lib64/
+parts/
+sdist/
+var/
+*.egg-info/
+.installed.cfg
+*.egg
+
+# Virtual environment
+venv/
+ENV/
+
+# pyenv
+.python-version
+
+# mypy
+.mypy_cache/
+.dmypy.json
+
+# Pytest
+.cache/
+
+# VSCode
+.vscode/
+

--- a/README.md
+++ b/README.md
@@ -1,1 +1,31 @@
-# API-Data
+# Yahoo Finance Microservice
+
+This project provides a simple FastAPI microservice that serves Yahoo Finance price history for a given ticker.
+
+## Requirements
+
+- Python 3.12
+
+Create a virtual environment and install dependencies:
+
+```bash
+python3.12 -m venv venv
+source venv/bin/activate
+pip install -r requirements.txt
+```
+
+## Running the service
+
+```bash
+uvicorn app.main:app --reload
+```
+
+Then visit `http://localhost:8000/history/MSFT` to fetch Microsoft stock history for the last year.
+
+The microservice always returns one year of historical data for the requested ticker.
+
+## Running tests
+
+```bash
+pytest
+```

--- a/app/main.py
+++ b/app/main.py
@@ -1,0 +1,18 @@
+from fastapi import FastAPI, HTTPException
+import yfinance as yf
+
+app = FastAPI(title="Yahoo Finance History Service")
+
+@app.get("/")
+async def root():
+    return {"message": "Yahoo Finance microservice"}
+
+@app.get("/history/{symbol}")
+async def get_history(symbol: str):
+    """Return 1-year historical price data for ``symbol``."""
+    try:
+        data = yf.Ticker(symbol).history(period="1y")
+    except Exception as e:
+        raise HTTPException(status_code=500, detail=str(e))
+
+    return data.reset_index().to_dict(orient="records")

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,5 @@
+fastapi
+uvicorn[standard]
+yfinance
+pytest
+httpx

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -1,0 +1,34 @@
+import os
+import sys
+from fastapi.testclient import TestClient
+
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
+
+from app.main import app
+
+client = TestClient(app)
+
+def test_root():
+    response = client.get("/")
+    assert response.status_code == 200
+    assert response.json()["message"].startswith("Yahoo Finance")
+
+def test_history(monkeypatch):
+    import pandas as pd
+    import yfinance as yf
+
+    called = {}
+    df = pd.DataFrame({"Date": [pd.Timestamp("2024-01-01")], "Close": [1]}).set_index("Date")
+
+    class DummyTicker:
+        def history(self, period="1y"):
+            called["period"] = period
+            return df
+
+    monkeypatch.setattr(yf, "Ticker", lambda symbol: DummyTicker())
+
+    response = client.get("/history/TEST")
+    assert response.status_code == 200
+    assert called["period"] == "1y"
+    data = response.json()
+    assert data[0]["Close"] == 1


### PR DESCRIPTION
## Summary
- simplify `/history/{symbol}` endpoint to always return 1-year data
- update README to describe fixed period behavior
- trim tests to match simplified API

## Testing
- `pip install -r requirements.txt`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68734b61ad2c83289e08984d7a991552