### PR TITLE
Pin httpx and ignore pytest cache

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,23 @@
+name: CI
+
+on:
+  push:
+    branches: [ main ]
+  pull_request:
+    branches: [ main ]
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v3
+    - name: Set up Python
+      uses: actions/setup-python@v4
+      with:
+        python-version: '3.12'
+    - name: Install dependencies
+      run: |
+        python -m pip install --upgrade pip
+        pip install -r requirements.txt
+    - name: Run tests
+      run: pytest

--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,55 @@
+__pycache__/
+*.py[cod]
+*.egg
+*.egg-info/
+.dist
+build/
+.env
+venv/
+.env/
+*.sqlite3
+*.db
+.DS_Store
+
+# Byte-compiled / optimized / DLL files
+__pycache__
+*.py[cod]
+*.so
+
+# C extensions
+*.so
+
+# Distribution / packaging
+.Python
+build/
+develop-eggs/
+dist/
+downloads/
+.eggs/
+lib/
+lib64/
+parts/
+sdist/
+var/
+*.egg-info/
+.installed.cfg
+*.egg
+
+# Virtual environment
+venv/
+ENV/
+
+# pyenv
+.python-version
+
+# mypy
+.mypy_cache/
+.dmypy.json
+
+# Pytest
+.cache/
+.pytest_cache/
+
+# VSCode
+.vscode/
+

--- a/README.md
+++ b/README.md
@@ -1,1 +1,47 @@
-# API-Data
+# Yahoo Finance Microservice
+
+This project provides a simple FastAPI microservice that serves Yahoo Finance price history for a given ticker.
+
+## Requirements
+
+- Python 3.12
+
+Create a virtual environment and install dependencies:
+
+```bash
+python3.12 -m venv venv
+source venv/bin/activate
+pip install -r requirements.txt
+```
+
+## Running the service
+
+```bash
+uvicorn app.main:app --reload
+```
+
+The service exposes a `/history` endpoint that accepts a stock symbol and
+optional query parameters. Example:
+
+```bash
+curl 'http://localhost:8000/history?symbol=MSFT&timeframe=6mo&start=2024-01-01&end=2024-06-30'
+```
+
+Query parameters:
+
+- `symbol` (required): stock ticker symbol.
+- `timeframe` (optional, default `1y`): history period accepted by yfinance.
+- `start` / `end` (optional): date range in `YYYY-MM-DD` format.
+- `include_dividends` and `include_splits` (optional): include those columns when set to `true`.
+
+The service also provides `/history/chart`, which returns a candlestick chart as a PNG image using the same query parameters.
+
+```bash
+curl 'http://localhost:8000/history/chart?symbol=MSFT&timeframe=1mo'
+```
+
+## Running tests
+
+```bash
+pytest
+```

--- a/app/main.py
+++ b/app/main.py
@@ -1,0 +1,87 @@
+from datetime import date
+from typing import Optional
+
+from fastapi import FastAPI, HTTPException
+from fastapi.responses import Response
+import yfinance as yf
+import mplfinance as mpf
+import io
+
+app = FastAPI(title="Yahoo Finance History Service")
+
+@app.get("/")
+async def root():
+    return {"message": "Yahoo Finance microservice"}
+
+@app.get("/history")
+async def get_history(
+    symbol: str,
+    timeframe: str = "1y",
+    start: Optional[date] = None,
+    end: Optional[date] = None,
+    include_dividends: bool = False,
+    include_splits: bool = False,
+):
+    """Return historical price data for ``symbol``.
+
+    Parameters
+    ----------
+    symbol: Stock ticker symbol
+    timeframe: History period accepted by yfinance (default ``"1y"``)
+    start: Optional start date in ``YYYY-MM-DD`` format
+    end: Optional end date in ``YYYY-MM-DD`` format
+    include_dividends: Include the ``Dividends`` column when ``True``
+    include_splits: Include the ``Stock Splits`` column when ``True``
+    """
+    try:
+        data = yf.Ticker(symbol).history(
+            period=timeframe,
+            start=start,
+            end=end,
+        )
+    except Exception as e:
+        raise HTTPException(status_code=500, detail=str(e))
+
+    data = data.reset_index()
+    drop_cols = []
+    if not include_dividends and "Dividends" in data.columns:
+        drop_cols.append("Dividends")
+    if not include_splits and "Stock Splits" in data.columns:
+        drop_cols.append("Stock Splits")
+    if drop_cols:
+        data = data.drop(columns=drop_cols)
+
+    return data.to_dict(orient="records")
+
+
+@app.get("/history/chart")
+async def get_history_chart(
+    symbol: str,
+    timeframe: str = "1y",
+    start: Optional[date] = None,
+    end: Optional[date] = None,
+    include_dividends: bool = False,
+    include_splits: bool = False,
+):
+    """Return a candlestick chart PNG for ``symbol``."""
+    try:
+        data = yf.Ticker(symbol).history(
+            period=timeframe,
+            start=start,
+            end=end,
+        )
+    except Exception as e:
+        raise HTTPException(status_code=500, detail=str(e))
+
+    drop_cols = []
+    if not include_dividends and "Dividends" in data.columns:
+        drop_cols.append("Dividends")
+    if not include_splits and "Stock Splits" in data.columns:
+        drop_cols.append("Stock Splits")
+    if drop_cols:
+        data = data.drop(columns=drop_cols)
+
+    buf = io.BytesIO()
+    mpf.plot(data, type="candle", style="charles", volume=True, savefig=buf)
+    buf.seek(0)
+    return Response(content=buf.read(), media_type="image/png")

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,6 @@
+fastapi
+uvicorn[standard]
+yfinance
+pytest
+httpx<0.28
+mplfinance

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -1,0 +1,124 @@
+import os
+import sys
+from fastapi.testclient import TestClient
+
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
+
+from app.main import app
+
+client = TestClient(app)
+
+def test_root():
+    response = client.get("/")
+    assert response.status_code == 200
+    assert response.json()["message"].startswith("Yahoo Finance")
+
+def test_history_params(monkeypatch):
+    import pandas as pd
+    import yfinance as yf
+
+    called = {}
+    df = pd.DataFrame(
+        {
+            "Date": [pd.Timestamp("2024-01-01")],
+            "Close": [1],
+            "Dividends": [0],
+            "Stock Splits": [0],
+        }
+    ).set_index("Date")
+
+    class DummyTicker:
+        def history(self, period="1y", start=None, end=None):
+            called["period"] = period
+            called["start"] = start
+            called["end"] = end
+            return df
+
+    monkeypatch.setattr(yf, "Ticker", lambda symbol: DummyTicker())
+
+    response = client.get(
+        "/history",
+        params={
+            "symbol": "TEST",
+            "timeframe": "1mo",
+            "start": "2024-01-01",
+            "end": "2024-01-31",
+        },
+    )
+    assert response.status_code == 200
+    assert called["period"] == "1mo"
+    assert str(called["start"]) == "2024-01-01"
+    assert str(called["end"]) == "2024-01-31"
+    data = response.json()
+    assert "Dividends" not in data[0]
+    assert "Stock Splits" not in data[0]
+    assert data[0]["Close"] == 1
+
+
+def test_history_include_extras(monkeypatch):
+    import pandas as pd
+    import yfinance as yf
+
+    df = pd.DataFrame(
+        {
+            "Date": [pd.Timestamp("2024-01-01")],
+            "Close": [1],
+            "Dividends": [0.5],
+            "Stock Splits": [2],
+        }
+    ).set_index("Date")
+
+    class DummyTicker:
+        def history(self, period="1y", start=None, end=None):
+            return df
+
+    monkeypatch.setattr(yf, "Ticker", lambda symbol: DummyTicker())
+
+    response = client.get(
+        "/history",
+        params={
+            "symbol": "TEST",
+            "include_dividends": "true",
+            "include_splits": "true",
+        },
+    )
+    assert response.status_code == 200
+    data = response.json()
+    assert data[0]["Dividends"] == 0.5
+    assert data[0]["Stock Splits"] == 2
+
+
+def test_history_chart(monkeypatch):
+    import pandas as pd
+    import yfinance as yf
+    import mplfinance as mpf
+
+    df = pd.DataFrame(
+        {
+            "Date": [pd.Timestamp("2024-01-01")],
+            "Open": [1],
+            "High": [2],
+            "Low": [0.5],
+            "Close": [1.5],
+            "Volume": [100],
+            "Dividends": [0],
+            "Stock Splits": [0],
+        }
+    ).set_index("Date")
+
+    class DummyTicker:
+        def history(self, period="1y", start=None, end=None):
+            return df
+
+    monkeypatch.setattr(yf, "Ticker", lambda symbol: DummyTicker())
+
+    def dummy_plot(data, type="candle", style="charles", volume=True, savefig=None):
+        if savefig is not None:
+            savefig.write(b"img")
+
+    monkeypatch.setattr(mpf, "plot", dummy_plot)
+
+    response = client.get("/history/chart", params={"symbol": "TEST"})
+    assert response.status_code == 200
+    assert response.headers["content-type"] == "image/png"
+    assert response.content == b"img"


### PR DESCRIPTION
## Summary
- ignore `.pytest_cache` so pytest artifacts aren't committed
- pin `httpx<0.28` to avoid incompatibility with FastAPI's TestClient

## Testing
- `pip install -r requirements.txt`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68734b61ad2c83289e08984d7a991552